### PR TITLE
Add missing 'use strict';

### DIFF
--- a/src/tasks/run.js
+++ b/src/tasks/run.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var AppTask = cb_require('tasks/app-task'),
 	utils = cli.utils;
 


### PR DESCRIPTION
Without `use strict` the following error happens (because the `let` variables): 
`
SyntaxError: Block-scoped declarations (let, const, function, class) not yet sup
ported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
`